### PR TITLE
fdci_job: Receive dict instead of str for configuration

### DIFF
--- a/modules/dci_job.py
+++ b/modules/dci_job.py
@@ -13,7 +13,6 @@
 
 from ansible.module_utils.basic import *
 
-import json
 import os
 
 try:
@@ -119,7 +118,7 @@ def main():
             remoteci=dict(type='str'),
             comment=dict(type='str'),
             status=dict(type='str'),
-            configuration=dict(type='str'),
+            configuration=dict(type='dict'),
         ),
     )
 
@@ -174,7 +173,7 @@ def main():
             if module.params['status']:
                 kwargs['status'] = module.params['status']
             if module.params['configuration']:
-                kwargs['configuration'] = json.loads(module.params['configuration'])
+                kwargs['configuration'] = module.params['configuration']
             res = dci_job.update(ctx, **kwargs)
 
     # Action required: Schedule a new job


### PR DESCRIPTION
The configuration paramter of the dci_job module should be a dict and
not a str.

With this patch user can simply pass a dict to configuration and this
dict will be properly passed to the DCI API, instead of having to
manipulate a string.